### PR TITLE
Add pkg metadata

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,6 @@
+#lang setup/infotab
+
+(define collection 'multi)
+(define deps '("base" "rackunit-lib" "compatibility-lib"))
+(define build-deps '("scribble-lib" "racket-doc"))
+


### PR DESCRIPTION
Adds package metadata so it installs to the right collection path (needed because Racket switched to single collection packages by default).
